### PR TITLE
feat: add feature flag to toggle new products UI

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,3 @@
+{
+  "isNewProductsUIEnabled": false
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,21 +5,31 @@ import App from "./App.tsx";
 import { MantineProvider } from "@mantine/core";
 import { ProductsModule } from "./modules/Products/index.tsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FeatureFlagProvider } from "./modules/feature-flags/index.tsx";
 
-
-
-const { Provider: ProductsProvider } = ProductsModule();
 const queryClient = new QueryClient({
   defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } },
 });
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <MantineProvider>
-        <QueryClientProvider client={queryClient}>
-          <ProductsProvider>
-            <App />
-          </ProductsProvider>
-        </QueryClientProvider>
-    </MantineProvider>
-  </StrictMode>,
-);
+
+(function start() {
+  fetch("/config.json")
+    .then((res) => res.json())
+    .then((config) => {
+      const { Provider: ProductsProvider } = ProductsModule();
+      console.log({ config });
+
+      createRoot(document.getElementById("root")!).render(
+        <StrictMode>
+          <MantineProvider>
+            <FeatureFlagProvider value={config}>
+              <QueryClientProvider client={queryClient}>
+                <ProductsProvider>
+                  <App />
+                </ProductsProvider>
+              </QueryClientProvider>
+            </FeatureFlagProvider>
+          </MantineProvider>
+        </StrictMode>,
+      );
+    });
+})();

--- a/src/modules/Products/views/index.tsx
+++ b/src/modules/Products/views/index.tsx
@@ -5,6 +5,7 @@ import { useProductsFilters } from "../hooks/useProductsFilters";
 import { useGetProducts } from "../hooks/useGetProducts";
 import { useProductsView } from "../hooks/useProductsView";
 import ProductsFilters from "./ProductFilter";
+import { useFeatureFlag } from "../../feature-flags";
 
 export const Products = () => {
   const filters = useProductsFilters();
@@ -25,7 +26,16 @@ export const Products = () => {
     sortBy: filters.priceSort,
   });
 
+  const { isNewProductsUIEnabled } = useFeatureFlag();
+
   const totalPages = Math.ceil(total / filters.POSTS_PER_PAGE);
+
+  if (isNewProductsUIEnabled)
+    return (
+      <Text mt="xl" size="xl">
+        New Products UI Coming Soon!
+      </Text>
+    );
 
   return (
     <Container size="xl">

--- a/src/modules/feature-flags/index.tsx
+++ b/src/modules/feature-flags/index.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type PropsWithChildren } from "react";
+
+type featureFlagProps = {
+  isNewProductsUIEnabled: boolean;
+};
+
+const FeatureFlagContext = createContext<featureFlagProps | null>(null);
+
+export const FeatureFlagProvider = ({
+  children,
+  value,
+}: PropsWithChildren<{ value: featureFlagProps }>) => {
+  return (
+    <FeatureFlagContext.Provider value={value}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+};
+
+export function useFeatureFlag() {
+  const context = useContext(FeatureFlagContext);
+
+  if (!context) {
+    throw new Error("useFeatureFlag must be used within a FeatureFlagProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
This PR introduces a runtime feature flag system and uses it to control the visibility of the new Products UI.

Feature flags are loaded at application startup from config.json, allowing Products UI behavior to be toggled without rebuilding or redeploying the app.

closes #16 